### PR TITLE
Add FabricAPI

### DIFF
--- a/tensai-fabric/build.gradle
+++ b/tensai-fabric/build.gradle
@@ -8,4 +8,5 @@ dependencies {
 	minecraft("com.mojang:minecraft:1.19.3")
 	mappings("net.fabricmc:yarn:1.19.3+build.5:v2")
 	modImplementation("net.fabricmc:fabric-loader:0.14.12")
+	modImplementation("net.fabricmc.fabric-api:fabric-api:0.70.0+1.19.3")
 }


### PR DESCRIPTION
Despite some backward compatibility drawbacks, using ``fabric`` is still the best option for developing.