### PR TITLE
Add unit test and test mod

### DIFF
--- a/tensai-api/build.gradle
+++ b/tensai-api/build.gradle
@@ -1,0 +1,7 @@
+dependencies {
+	testImplementation 'org.junit.jupiter:junit-jupiter:5.8.1'
+}
+
+tasks.named('test') {
+	useJUnitPlatform()
+}

--- a/tensai-api/src/main/java/dev/vmsa/tensai/utils/Vec4.java
+++ b/tensai-api/src/main/java/dev/vmsa/tensai/utils/Vec4.java
@@ -27,6 +27,7 @@ package dev.vmsa.tensai.utils;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
+import java.util.Objects;
 
 import dev.vmsa.tensai.networking.Serializer;
 import dev.vmsa.tensai.vfx.animations.AnimationProperty;
@@ -74,6 +75,24 @@ public class Vec4 {
 	@Override
 	public String toString() {
 		return "Vec4 [x=" + x + ", y=" + y + ", z=" + z + ", w=" + w + "]";
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(w, x, y, z);
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) return true;
+		if (obj == null) return false;
+		if (getClass() != obj.getClass()) return false;
+
+		Vec4 other = (Vec4) obj;
+		return Double.doubleToLongBits(w) == Double.doubleToLongBits(other.w)
+				&& Double.doubleToLongBits(x) == Double.doubleToLongBits(other.x)
+				&& Double.doubleToLongBits(y) == Double.doubleToLongBits(other.y)
+				&& Double.doubleToLongBits(z) == Double.doubleToLongBits(other.z);
 	}
 
 	public static final Serializer<Vec4> SERIALIZER = new Serializer<Vec4>() {

--- a/tensai-api/src/test/java/dev/vmsa/tensai/tests/junit/SerializationTest.java
+++ b/tensai-api/src/test/java/dev/vmsa/tensai/tests/junit/SerializationTest.java
@@ -1,0 +1,112 @@
+/*
+ * This file is part of tensai, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2022 VMSA
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package dev.vmsa.tensai.tests.junit;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.Test;
+
+import dev.vmsa.tensai.utils.Vec4;
+import dev.vmsa.tensai.vfx.animations.AnimationProperty;
+
+class SerializationTest {
+	@Test
+	void testVec4() throws IOException {
+		Vec4 vec = new Vec4(1, 2, 3, 4);
+		byte[] vecBinary = Utils.createBytes(stream -> Vec4.SERIALIZER.serialize(vec, stream));
+		assertEquals(vec, Vec4.SERIALIZER.deserialize(Utils.createStream(vecBinary)));
+	}
+
+	void checkAnimationProperty(Class<?> expectedType, AnimationProperty<?> expected, AnimationProperty<?> actual) {
+		assertEquals(expected.getName(), actual.getName());
+		assertEquals(expected.getValue(), actual.getValue());
+		assertEquals(expectedType, actual.getValue().getClass());
+	}
+
+	// Exact
+	void animationPropExact(Class<?> type, AnimationProperty<?> prop) throws IOException {
+		byte[] propBinary = Utils.createBytes(stream -> AnimationProperty.SERIALIZER.serialize(prop, stream));
+		AnimationProperty<?> deserialized = AnimationProperty.SERIALIZER.deserialize(Utils.createStream(propBinary));
+		assertEquals(prop.getName(), deserialized.getName());
+		assertEquals(prop.getValue(), deserialized.getValue());
+		assertEquals(type, deserialized.getValue().getClass());
+	}
+
+	@Test
+	void testAnimationPropertyLong() throws IOException {
+		animationPropExact(Long.class, new AnimationProperty<>("prop", 0xFFFFFFFFFFFFFFFFL));
+	}
+
+	@Test
+	void testAnimationPropertyDouble() throws IOException {
+		animationPropExact(Double.class, new AnimationProperty<>("prop", 3.1415926535898D));
+	}
+
+	@Test
+	void testAnimationPropertyString() throws IOException {
+		animationPropExact(String.class, new AnimationProperty<>("prop", "Hello world"));
+	}
+
+	@Test
+	void testAnimationPropertyVec4() throws IOException {
+		animationPropExact(Vec4.class, new AnimationProperty<>("prop", new Vec4(1, 2, 3, 4)));
+	}
+
+	// Casted
+	void animationPropCasted(Class<?> type, AnimationProperty<?> prop, Object value) throws IOException {
+		byte[] propBinary = Utils.createBytes(stream -> AnimationProperty.SERIALIZER.serialize(prop, stream));
+		AnimationProperty<?> deserialized = AnimationProperty.SERIALIZER.deserialize(Utils.createStream(propBinary));
+		assertEquals(prop.getName(), deserialized.getName());
+		assertEquals(type, deserialized.getValue().getClass());
+		assertEquals(value, deserialized.getValue());
+	}
+
+	@Test
+	void testAnimationPropertyByte() throws IOException {
+		animationPropCasted(Long.class, new AnimationProperty<>("prop", (byte) 127), 127L);
+	}
+
+	@Test
+	void testAnimationPropertyShort() throws IOException {
+		animationPropCasted(Long.class, new AnimationProperty<>("prop", (short) 32767), 32767L);
+	}
+
+	@Test
+	void testAnimationPropertyInt() throws IOException {
+		animationPropCasted(Long.class, new AnimationProperty<>("prop", -1), -1L);
+	}
+
+	@Test
+	void testAnimationPropertyFloat() throws IOException {
+		AnimationProperty<Float> prop = new AnimationProperty<>("prop", 3.1415926535898F);
+		byte[] propBinary = Utils.createBytes(stream -> AnimationProperty.SERIALIZER.serialize(prop, stream));
+		AnimationProperty<?> deserialized = AnimationProperty.SERIALIZER.deserialize(Utils.createStream(propBinary));
+
+		assertEquals(prop.getName(), deserialized.getName());
+		assertEquals(Double.class, deserialized.getValue().getClass());
+	}
+}

--- a/tensai-api/src/test/java/dev/vmsa/tensai/tests/junit/Utils.java
+++ b/tensai-api/src/test/java/dev/vmsa/tensai/tests/junit/Utils.java
@@ -1,0 +1,55 @@
+/*
+ * This file is part of tensai, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2022 VMSA
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package dev.vmsa.tensai.tests.junit;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInput;
+import java.io.DataInputStream;
+import java.io.DataOutput;
+import java.io.DataOutputStream;
+import java.io.IOException;
+
+/**
+ * <p>Test utilities.</p>
+ *
+ */
+public class Utils {
+	public static byte[] createBytes(BinaryWriter writer) throws IOException {
+		ByteArrayOutputStream stream = new ByteArrayOutputStream();
+		DataOutputStream wrapper = new DataOutputStream(stream);
+		writer.write(wrapper);
+		return stream.toByteArray();
+	}
+
+	public static DataInput createStream(byte[] bytes) {
+		return new DataInputStream(new ByteArrayInputStream(bytes));
+	}
+
+	@FunctionalInterface
+	public interface BinaryWriter {
+		void write(DataOutput stream) throws IOException;
+	}
+}

--- a/tensai-fabric/build.gradle
+++ b/tensai-fabric/build.gradle
@@ -10,3 +10,19 @@ dependencies {
 	modImplementation("net.fabricmc:fabric-loader:0.14.12")
 	modImplementation("net.fabricmc.fabric-api:fabric-api:0.70.0+1.19.3")
 }
+
+loom {
+	runs {
+		testClient {
+			inherit client
+			configName = "Test Minecraft Client"
+			source = sourceSets.test
+		}
+
+		testServer {
+			inherit server
+			configName = "Test Minecraft Server"
+			source = sourceSets.test
+		}
+	}
+}

--- a/tensai-fabric/src/main/resources/fabric.mod.json
+++ b/tensai-fabric/src/main/resources/fabric.mod.json
@@ -3,7 +3,7 @@
   "id": "tensai",
   "name": "Tensai",
   "version": "${version}",
-  "environment": "server",
+  "environment": "*",
   "license": "MIT",
   "authors": [
     "VMSA"

--- a/tensai-fabric/src/test/java/dev/vmsa/tensai/fabric/test/TensaiFabricTestMod.java
+++ b/tensai-fabric/src/test/java/dev/vmsa/tensai/fabric/test/TensaiFabricTestMod.java
@@ -1,0 +1,47 @@
+/*
+ * This file is part of tensai, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2022 VMSA
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package dev.vmsa.tensai.fabric.test;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import net.fabricmc.api.ModInitializer;
+import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback;
+
+import dev.vmsa.tensai.fabric.test.commands.TensaiTestCommand;
+
+public class TensaiFabricTestMod implements ModInitializer {
+	public static final String MOD_ID = "tensai-test";
+	public static final Logger LOGGER = LoggerFactory.getLogger(MOD_ID);
+
+	@Override
+	public void onInitialize() {
+		LOGGER.info("Hello world!");
+
+		CommandRegistrationCallback.EVENT.register((dispatcher, registryAccess, environment) -> {
+			dispatcher.register(TensaiTestCommand.tensaiTest());
+		});
+	}
+}

--- a/tensai-fabric/src/test/java/dev/vmsa/tensai/fabric/test/client/PluginMessagingChannelListener.java
+++ b/tensai-fabric/src/test/java/dev/vmsa/tensai/fabric/test/client/PluginMessagingChannelListener.java
@@ -1,0 +1,108 @@
+/*
+ * This file is part of tensai, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2022 VMSA
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package dev.vmsa.tensai.fabric.test.client;
+
+import java.io.ByteArrayInputStream;
+import java.io.DataInputStream;
+import java.io.IOException;
+
+import net.minecraft.text.Text;
+import net.minecraft.util.Formatting;
+import net.minecraft.util.Identifier;
+
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
+
+import dev.vmsa.tensai.networking.PluginMessage;
+
+@Environment(EnvType.CLIENT)
+public class PluginMessagingChannelListener {
+	private static final int BYTES_PER_ROW = 16;
+	private static final String HEADER = "____ |  0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f | 0   4   8   c   ";
+	private static final String DISPLAYABLE_CHARS = "0123456789!@#$%^&*()-=_+`~[]{};':\"\\|,./<>?abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXZ";
+
+	public static void listen(Identifier channel) {
+		Text prefix = Text.literal("[Tensai] ").formatted(Formatting.GOLD)
+				.append(Text.literal(channel.toString()).formatted(Formatting.YELLOW))
+				.append(Text.literal(" >> ").formatted(Formatting.DARK_GRAY));
+
+		ClientPlayNetworking.registerGlobalReceiver(new Identifier(PluginMessage.CHANNEL_VFX), (client, handler, buf, responseSender) -> {
+			byte[] bs = buf.array();
+			String messageType = "(unknown)";
+
+			try (DataInputStream stream = new DataInputStream(new ByteArrayInputStream(bs))) {
+				messageType = stream.readUTF();
+			} catch (IOException e) {
+				e.printStackTrace();
+			}
+
+			client.inGameHud.getChatHud().addMessage(Text.empty()
+					.append(prefix)
+					.append(Text.literal(messageType).formatted(Formatting.WHITE)));
+
+			TensaiFabricTestClient.LOGGER.info("Displaying bytes for message type {}:", messageType);
+			logBytes(buf.array());
+		});
+
+		TensaiFabricTestClient.LOGGER.info("Now listening for messages from {} channel", channel);
+	}
+
+	private static String createHex(int bv, int size) {
+		String s = Integer.toHexString(bv);
+		while (s.length() < size) s = "0" + s;
+		return s;
+	}
+
+	private static String spaces(String s, int max) {
+		while (s.length() < max) s += " ";
+		return s;
+	}
+
+	private static void logBytes(byte[] bs) {
+		TensaiFabricTestClient.LOGGER.info(HEADER);
+		String left = "";
+		String right = "";
+
+		for (int i = 0; i < bs.length; i++) {
+			if (i != 0 && (i % BYTES_PER_ROW) == 0) {
+				TensaiFabricTestClient.LOGGER.info(createHex((i - 1) >> 4, 3) + "x | " + left + "| " + right);
+				left = ""; right = "";
+			}
+
+			int uint = Byte.toUnsignedInt(bs[i]);
+			left += createHex(uint, 2) + " ";
+			
+			int chIdx = DISPLAYABLE_CHARS.indexOf(uint);
+			right += chIdx != -1? ((char) uint) : '.';
+		}
+
+		if (left.length() != 0) TensaiFabricTestClient.LOGGER.info(createHex((bs.length - 1) >> 4, 3) + "x | " + spaces(left, 48) + "| " + right);
+	}
+
+	public static void main(String[] args) {
+		logBytes(new byte[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19});
+	}
+}

--- a/tensai-fabric/src/test/java/dev/vmsa/tensai/fabric/test/client/PluginMessagingChannelListener.java
+++ b/tensai-fabric/src/test/java/dev/vmsa/tensai/fabric/test/client/PluginMessagingChannelListener.java
@@ -45,7 +45,7 @@ public class PluginMessagingChannelListener {
 	private static final String DISPLAYABLE_CHARS = "0123456789!@#$%^&*()-=_+`~[]{};':\"\\|,./<>?abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXZ";
 
 	public static void listen(Identifier channel) {
-		Text prefix = Text.literal("[Tensai] ").formatted(Formatting.GOLD)
+		Text prefix = Text.literal("[Client] ").formatted(Formatting.GOLD)
 				.append(Text.literal(channel.toString()).formatted(Formatting.YELLOW))
 				.append(Text.literal(" >> ").formatted(Formatting.DARK_GRAY));
 
@@ -61,7 +61,7 @@ public class PluginMessagingChannelListener {
 
 			client.inGameHud.getChatHud().addMessage(Text.empty()
 					.append(prefix)
-					.append(Text.literal(messageType).formatted(Formatting.WHITE)));
+					.append(Text.literal("Message type = " + messageType).formatted(Formatting.WHITE)));
 
 			TensaiFabricTestClient.LOGGER.info("Displaying bytes for message type {}:", messageType);
 			logBytes(buf.array());

--- a/tensai-fabric/src/test/java/dev/vmsa/tensai/fabric/test/client/TensaiFabricTestClient.java
+++ b/tensai-fabric/src/test/java/dev/vmsa/tensai/fabric/test/client/TensaiFabricTestClient.java
@@ -1,0 +1,47 @@
+/*
+ * This file is part of tensai, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2022 VMSA
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package dev.vmsa.tensai.fabric.test.client;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import net.minecraft.util.Identifier;
+
+import net.fabricmc.api.ClientModInitializer;
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import dev.vmsa.tensai.fabric.test.TensaiFabricTestMod;
+import dev.vmsa.tensai.networking.PluginMessage;
+
+@Environment(EnvType.CLIENT)
+public class TensaiFabricTestClient implements ClientModInitializer {
+	public static final Logger LOGGER = LoggerFactory.getLogger(TensaiFabricTestMod.MOD_ID + "-client");
+
+	@Override
+	public void onInitializeClient() {
+		LOGGER.info("Hello client!");
+		PluginMessagingChannelListener.listen(new Identifier(PluginMessage.CHANNEL_VFX));
+	}
+}

--- a/tensai-fabric/src/test/java/dev/vmsa/tensai/fabric/test/commands/AnimationCommand.java
+++ b/tensai-fabric/src/test/java/dev/vmsa/tensai/fabric/test/commands/AnimationCommand.java
@@ -1,0 +1,85 @@
+/*
+ * This file is part of tensai, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2022 VMSA
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package dev.vmsa.tensai.fabric.test.commands;
+
+import static net.minecraft.server.command.CommandManager.argument;
+import static net.minecraft.server.command.CommandManager.literal;
+
+import java.util.Collection;
+
+import com.mojang.brigadier.arguments.DoubleArgumentType;
+import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+import com.mojang.brigadier.context.CommandContext;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+
+import net.minecraft.command.argument.EntityArgumentType;
+import net.minecraft.command.argument.IdentifierArgumentType;
+import net.minecraft.server.command.ServerCommandSource;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.text.ClickEvent;
+import net.minecraft.text.HoverEvent;
+import net.minecraft.text.Text;
+import net.minecraft.util.Identifier;
+
+import dev.vmsa.tensai.fabric.clients.FabricClientHandle;
+
+public class AnimationCommand {
+	public static final String COMMAND = "animation";
+	public static final String COMMAND_PLAY = "play";
+
+	public static LiteralArgumentBuilder<ServerCommandSource> animation() {
+		LiteralArgumentBuilder<ServerCommandSource> ret = literal(COMMAND);
+		ret.then(argument("target", EntityArgumentType.players())
+				.then(playCommand()));
+		return ret;
+	}
+
+	private static LiteralArgumentBuilder<ServerCommandSource> playCommand() {
+		LiteralArgumentBuilder<ServerCommandSource> ret = literal("play");
+		ret.then(argument("type", IdentifierArgumentType.identifier())
+				.then(argument("start", DoubleArgumentType.doubleArg(0))
+						.then(argument("duration", DoubleArgumentType.doubleArg(0))
+								.executes(ctx -> playOnce(ctx, DoubleArgumentType.getDouble(ctx, "start"), DoubleArgumentType.getDouble(ctx, "duration"))))
+						.executes(ctx -> playOnce(ctx,  DoubleArgumentType.getDouble(ctx, "start"), Double.POSITIVE_INFINITY)))
+				.executes(ctx -> playOnce(ctx, 0, Double.POSITIVE_INFINITY)));
+		return ret;
+	}
+
+	private static int playOnce(CommandContext<ServerCommandSource> ctx, double startSec, double durationSec) throws CommandSyntaxException {
+		Identifier type = IdentifierArgumentType.getIdentifier(ctx, "type");
+		Collection<ServerPlayerEntity> players = EntityArgumentType.getPlayers(ctx, "target");
+		String command = "/" + TensaiTestCommand.COMMAND + " " + COMMAND + " @s " + COMMAND_PLAY + " " + type.toString();
+		Text clickableText = Text.literal(type.toString()).styled(s -> s
+				.withUnderline(true)
+				.withClickEvent(new ClickEvent(ClickEvent.Action.SUGGEST_COMMAND, command))
+				.withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, Text.literal(command))));
+
+		for (ServerPlayerEntity e : players) {
+			((FabricClientHandle) e).getVfx().playAnimationOnce(type.toString(), startSec, durationSec);
+			ctx.getSource().sendFeedback(Text.literal("Sent animation play request (").append(clickableText).append(") to ").append(e.getDisplayName()), true);
+		}
+		return 1;
+	}
+}

--- a/tensai-fabric/src/test/java/dev/vmsa/tensai/fabric/test/commands/TensaiTestCommand.java
+++ b/tensai-fabric/src/test/java/dev/vmsa/tensai/fabric/test/commands/TensaiTestCommand.java
@@ -1,0 +1,41 @@
+/*
+ * This file is part of tensai, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2022 VMSA
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package dev.vmsa.tensai.fabric.test.commands;
+
+import static net.minecraft.server.command.CommandManager.literal;
+
+import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+
+import net.minecraft.server.command.ServerCommandSource;
+
+public class TensaiTestCommand {
+	public static final String COMMAND = "tensaitest";
+
+	public static LiteralArgumentBuilder<ServerCommandSource> tensaiTest() {
+		LiteralArgumentBuilder<ServerCommandSource> ret = literal(COMMAND);
+		ret.then(AnimationCommand.animation());
+		return ret;
+	}
+}

--- a/tensai-fabric/src/test/resources/fabric.mod.json
+++ b/tensai-fabric/src/test/resources/fabric.mod.json
@@ -1,0 +1,24 @@
+{
+  "schemaVersion": 1,
+  "id": "tensai-testmod",
+  "name": "Tensai Test Mod",
+  "version": "${version}",
+  "environment": "*",
+  "license": "MIT",
+  "authors": [
+    "VMSA"
+  ],
+  "depends": {
+    "tensai": "*"
+  },
+  "entrypoints": {
+    "main": [
+      "dev.vmsa.tensai.fabric.test.TensaiFabricTestMod"
+    ],
+    "client": [
+      "dev.vmsa.tensai.fabric.test.client.TensaiFabricTestClient"
+    ]
+  },
+  "mixins": [
+  ]
+}


### PR DESCRIPTION
- Unit test: Just a standard JUnit test, placed in ``tensai-api/src/test``. Testing serialization for now.
- Test mod: Located in ``tensai-fabric/src/test``, this test mod is intended to capture incoming plugin messages from server to client. Run with ``gradlew :tensai-fabric:runTestClient`` or ``gradlew :tensai-fabric:runTestServer``.
  + I can't get ``testmod`` to work, so I just choose ``src/test`` instead.